### PR TITLE
feat: reject empty key in VigenereCipher

### DIFF
--- a/src/VigenereCipher.java
+++ b/src/VigenereCipher.java
@@ -11,6 +11,9 @@ public class VigenereCipher {
 
     /** Шифрование */
     public static String encrypt(String plaintext, String key) {
+        if (key.length() == 0) {
+            throw new IllegalArgumentException("Key must not be empty");
+        }
         StringBuilder out = new StringBuilder();
         key = key.toUpperCase();
         int keyPos = 0;
@@ -33,6 +36,9 @@ public class VigenereCipher {
 
     /** Расшифрование (обратный сдвиг) */
     public static String decrypt(String ciphertext, String key) {
+        if (key.length() == 0) {
+            throw new IllegalArgumentException("Key must not be empty");
+        }
         StringBuilder out = new StringBuilder();
         key = key.toUpperCase();
         int keyPos = 0;


### PR DESCRIPTION
## Summary
- add key length validation to `VigenereCipher` encrypt/decrypt
- throw `IllegalArgumentException` if key is empty

## Testing
- `javac -d . src/*.java`
- `java VigenereCipher`

------
https://chatgpt.com/codex/tasks/task_e_688691ee78748327be932791a1d50b67